### PR TITLE
Use Twine to upload to PyPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ format:
 	yapf -i $(NAME).py
 
 upload: lint
-	python setup.py sdist bdist_wheel upload --sign
+	python setup.py sdist bdist_wheel
+	twine upload -s dist/*
 
 clean:
 	$(RM) -r $(wildcard *.egg-info *.pyc) build dist


### PR DESCRIPTION
Twine has advantages over `python setup.py upload` as detailed [on its homepage](https://github.com/pypa/twine#why-should-i-use-this).