### PR TITLE
Drop support for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
 install:
   - pip install flake8 flake8-builtins flake8-docstrings flake8-import-order mypy pylint

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,7 @@ xdg
 ``xdg`` is a tiny Python module which provides the variables defined by the
 `XDG Base Directory Specification`_, to save you from duplicating the same
 snippet of logic in every Python utility you write that deals with user cache,
-configuration, or data files. It has no external dependencies and supports
-Python 2 and 3.
+configuration, or data files. It has no external dependencies.
 
 .. _`XDG Base Directory Specification`: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,15 @@
 """Setup module for xdg."""
 
-import os.path
+from pathlib import Path
 
 from setuptools import setup
 
 
-def source_root_dir():
-    """Return the path to the root of the source distribution."""
-    return os.path.abspath(os.path.dirname(__file__))
-
-
 def read_long_description():
     """Read from README.rst file in root of source directory."""
-    readme = os.path.join(source_root_dir(), 'README.rst')
-    with open(readme) as fin:
-        return fin.read()
+    root = Path(__file__).resolve().parent
+    readme = root / 'README.rst'
+    return readme.read_text()
 
 
 setup(
@@ -32,8 +27,7 @@ setup(
         'License :: OSI Approved :: ISC License (ISCL)',
         'Natural Language :: English',
         'Operating System :: Unix',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
     ],
     keywords='xdg base directory specification',
     py_modules=['xdg'],

--- a/xdg.py
+++ b/xdg.py
@@ -37,7 +37,7 @@ __all__ = ['XDG_CACHE_HOME', 'XDG_CONFIG_DIRS', 'XDG_CONFIG_HOME',
            'XDG_DATA_DIRS', 'XDG_DATA_HOME', 'XDG_RUNTIME_DIR']
 
 
-def _getenv(variable, default):
+def _getenv(variable: str, default: str) -> str:
     """Get an environment variable.
 
     Parameters


### PR DESCRIPTION
This allows us to use Python 3 features such as [type hints](https://docs.python.org/3/library/typing.html) and [`pathlib`](https://docs.python.org/3/library/pathlib.html).