### PR TITLE
Use platform native directory separator

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-Copyright © 2016-2017 Scott Stevenson <scott@stevenson.io>
+Copyright © 2016-2018 Scott Stevenson <scott@stevenson.io>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ variable of the same name, or ``None`` if the environment variable is unset.
 Copyright
 ---------
 
-Copyright © 2016-2017 `Scott Stevenson`_.
+Copyright © 2016-2018 `Scott Stevenson`_.
 
 ``xdg`` is distributed under the terms of the `ISC licence`_.
 

--- a/xdg.py
+++ b/xdg.py
@@ -57,12 +57,14 @@ def _getenv(variable: str, default: str) -> str:
     return os.environ.get(variable) or default
 
 
-XDG_CACHE_HOME = _getenv('XDG_CACHE_HOME', os.path.expandvars('$HOME/.cache'))
+XDG_CACHE_HOME = _getenv('XDG_CACHE_HOME',
+                         os.path.expandvars(os.path.join('$HOME', '.cache')))
 XDG_CONFIG_DIRS = _getenv('XDG_CONFIG_DIRS', '/etc/xdg').split(':')
 XDG_CONFIG_HOME = _getenv('XDG_CONFIG_HOME',
-                          os.path.expandvars('$HOME/.config'))
+                          os.path.expandvars(os.path.join('$HOME', '.config')))
 XDG_DATA_DIRS = _getenv('XDG_DATA_DIRS',
                         '/usr/local/share/:/usr/share/').split(':')
 XDG_DATA_HOME = _getenv('XDG_DATA_HOME',
-                        os.path.expandvars('$HOME/.local/share'))
+                        os.path.expandvars(
+                            os.path.join('$HOME', '.local', 'share')))
 XDG_RUNTIME_DIR = os.getenv('XDG_RUNTIME_DIR')

--- a/xdg.py
+++ b/xdg.py
@@ -17,7 +17,7 @@ variable of the same name, or None if the environment variable is not
 set.
 """
 
-# Copyright © 2016-2017 Scott Stevenson <scott@stevenson.io>
+# Copyright © 2016-2018 Scott Stevenson <scott@stevenson.io>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
The specification doesn't say anything about the portability of directory separators, but this change makes `xdg` more useful on Windows.

Closes #7 .