### PR TITLE
setup.py: read README with UTF-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read_long_description():
     """Read from README.rst file in root of source directory."""
     root = Path(__file__).resolve().parent
     readme = root / 'README.rst'
-    return readme.read_text()  # pylint: disable=no-member
+    return readme.read_text(encoding='utf-8')  # pylint: disable=no-member
 
 
 setup(


### PR DESCRIPTION
Ran into the following:

```
Traceback (most recent call last):
  File "nix_run_setup", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 19, in <module>
    long_description=read_long_description(),
  File "setup.py", line 12, in read_long_description
    return readme.read_text()  # pylint: disable=no-member
  File "/nix/store/p1bp0kpmxi7nzrla7n7c4waqic0a2myk-python3-3.6.4/lib/python3.6/pathlib.py", line 1175, in read_text
    return f.read()
  File "/nix/store/p1bp0kpmxi7nzrla7n7c4waqic0a2myk-python3-3.6.4/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1973: ordinal not in range(128)
builder for ‘/nix/store/qy4kksc5khygwbhkwg88h9fsmf02faad-python3.6-xdg-3.0.0.drv’ failed with exit code 1
```