### PR TITLE
Add configuration file and Pipenv script for mypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ install:
   - pip install pipenv
   - pipenv install --dev --skip-lock
 script:
+  - pipenv run mypy
   - make check

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 check: lint test
 
 lint:
-	pipenv run mypy --ignore-missing-imports --strict xdg.py test/*.py
 	pipenv run flake8 xdg.py test/*.py
 	pipenv run pylint -r n -s n xdg.py test/*.py
 

--- a/Pipfile
+++ b/Pipfile
@@ -19,3 +19,8 @@ wheel = "*"
 
 [requires]
 python_version = "3.7"
+
+[scripts]
+# We pass `--strict` here as mypy does not support specifying it in the
+# `mypy.ini` configuration file.
+mypy = "mypy --strict setup.py test/ xdg.py"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True


### PR DESCRIPTION
This makes it easier to use the project's preferred mypy configuration when running mypy within a text editor, for example.