### PR TITLE
Return paths as `pathlib.Path` objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,19 @@ from xdg import (XDG_CACHE_HOME, XDG_CONFIG_DIRS, XDG_CONFIG_HOME,
                  XDG_DATA_DIRS, XDG_DATA_HOME, XDG_RUNTIME_DIR)
 ```
 
-`XDG_CACHE_HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME` are strings containing
-the value of the environment variable of the same name, or the default defined
-in the specification if the environment variable is unset or empty.
+`XDG_CACHE_HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME` are [`pathlib.Path`
+objects][path] containing the value of the environment variable of the same
+name, or the default defined in the specification if the environment variable is
+unset or empty.
 
-`XDG_CONFIG_DIRS` and `XDG_DATA_DIRS` are lists of strings containing the value
-of the environment variable of the same name split on colons, or the default
-defined in the specification if the environment variable is unset or empty.
+`XDG_CONFIG_DIRS` and `XDG_DATA_DIRS` are lists of `pathlib.Path` objects
+containing the value of the environment variable of the same name split on
+colons, or the default defined in the specification if the environment variable
+is unset or empty.
 
-`XDG_RUNTIME_DIR` is a string containing the value of the environment variable
-of the same name, or `None` if the environment variable is unset.
+`XDG_RUNTIME_DIR` is a `pathlib.Path` object containing the value of the
+environment variable of the same name, or `None` if the environment variable is
+unset.
 
 ## Copyright
 
@@ -43,6 +46,7 @@ Copyright © 2016-2019 [Scott Stevenson].
 `xdg` is distributed under the terms of the [ISC licence].
 
 [isc licence]: https://opensource.org/licenses/ISC
+[path]: https://docs.python.org/3/library/pathlib.html#pathlib.Path
 [pip]: https://pip.pypa.io/en/stable/
 [pipenv]: https://docs.pipenv.org/
 [poetry]: https://poetry.eustace.io/

--- a/pylintrc
+++ b/pylintrc
@@ -1,4 +1,5 @@
 [MESSAGES CONTROL]
 
 # Disable the message, report, category or checker with the given name.
-disable=bad-continuation  # https://github.com/ambv/black/issues/48#issuecomment-408213493
+disable=bad-continuation,  # https://github.com/ambv/black/issues/48#issuecomment-408213493
+    fixme

--- a/src/xdg.py
+++ b/src/xdg.py
@@ -1,35 +1,40 @@
-"""XDG Base Directory Specification variables.
-
-XDG_CACHE_HOME, XDG_CONFIG_HOME, and XDG_DATA_HOME are strings
-containing the value of the environment variable of the same name, or
-the default defined in the specification if the environment variable is
-unset or empty.
-
-XDG_CONFIG_DIRS and XDG_DATA_DIRS are lists of strings containing the
-value of the environment variable of the same name split on colons, or
-the default defined in the specification if the environment variable is
-unset or empty.
-
-XDG_RUNTIME_DIR is a string containing the value of the environment
-variable of the same name, or None if the environment variable is not
-set.
-"""
-
 # Copyright © 2016-2019 Scott Stevenson <scott@stevenson.io>
 #
-# Permission to use, copy, modify, and/or distribute this software for any
-# purpose with or without fee is hereby granted, provided that the above
-# copyright notice and this permission notice appear in all copies.
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all
+# copies.
 #
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-# AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-# INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-# LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+# DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+# PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+# TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 # PERFORMANCE OF THIS SOFTWARE.
 
+"""XDG Base Directory Specification variables.
+
+XDG_CACHE_HOME, XDG_CONFIG_HOME, and XDG_DATA_HOME are pathlib.Path
+objects containing the value of the environment variable of the same
+name, or the default defined in the specification if the environment
+variable is unset or empty.
+
+XDG_CONFIG_DIRS and XDG_DATA_DIRS are lists of pathlib.Path objects
+containing the value of the environment variable of the same name split
+on colons, or the default defined in the specification if the
+environment variable is unset or empty.
+
+XDG_RUNTIME_DIR is a pathlib.Path object containing the value of the
+environment variable of the same name, or None if the environment
+variable is not set.
+
+"""
+
 import os
+from pathlib import Path
+from typing import List, Optional
 
 __all__ = [
     "XDG_CACHE_HOME",
@@ -40,39 +45,78 @@ __all__ = [
     "XDG_RUNTIME_DIR",
 ]
 
+HOME = Path(os.path.expandvars("$HOME"))
 
-def _getenv(variable: str, default: str) -> str:
-    """Get an environment variable.
+
+def _path_from_env(variable: str, default: Path) -> Path:
+    """Read an environment variable as a path.
+
+    The environment variable with the specified name is read, and its
+    value returned as a path. If the environment variable is not set, or
+    set to the empty string, the default value is returned.
 
     Parameters
     ----------
     variable : str
-        The environment variable.
-    default : str
-        A default value that will be returned if the environment
-        variable is unset or empty.
+        Name of the environment variable.
+    default : Path
+        Default value.
 
     Returns
     -------
-    str
-        The value of the environment variable, or the default value.
+    Path
+        Value from environment or default.
 
     """
-    return os.environ.get(variable) or default
+    # TODO(srstevenson): Use assignment expression in Python 3.8.
+    value = os.environ.get(variable)
+    if value:
+        return Path(value)
+    return default
 
 
-XDG_CACHE_HOME = _getenv(
-    "XDG_CACHE_HOME", os.path.expandvars(os.path.join("$HOME", ".cache"))
+def _paths_from_env(variable: str, default: List[Path]) -> List[Path]:
+    """Read an environment variable as a list of paths.
+
+    The environment variable with the specified name is read, and its
+    value split on colons and returned as a list of paths. If the
+    environment variable is not set, or set to the empty string, the
+    default value is returned.
+
+    Parameters
+    ----------
+    variable : str
+        Name of the environment variable.
+    default : List[Path]
+        Default value.
+
+    Returns
+    -------
+    List[Path]
+        Value from environment or default.
+
+    """
+    # TODO(srstevenson): Use assignment expression in Python 3.8.
+    value = os.environ.get(variable)
+    if value:
+        return [Path(path) for path in value.split(":")]
+    return default
+
+
+XDG_CACHE_HOME = _path_from_env("XDG_CACHE_HOME", HOME / ".cache")
+
+XDG_CONFIG_DIRS = _paths_from_env("XDG_CONFIG_DIRS", [Path("/etc/xdg")])
+
+XDG_CONFIG_HOME = _path_from_env("XDG_CONFIG_HOME", HOME / ".config")
+
+XDG_DATA_DIRS = _paths_from_env(
+    "XDG_DATA_DIRS",
+    [Path(path) for path in "/usr/local/share/:/usr/share/".split(":")],
 )
-XDG_CONFIG_DIRS = _getenv("XDG_CONFIG_DIRS", "/etc/xdg").split(":")
-XDG_CONFIG_HOME = _getenv(
-    "XDG_CONFIG_HOME", os.path.expandvars(os.path.join("$HOME", ".config"))
-)
-XDG_DATA_DIRS = _getenv(
-    "XDG_DATA_DIRS", "/usr/local/share/:/usr/share/"
-).split(":")
-XDG_DATA_HOME = _getenv(
-    "XDG_DATA_HOME",
-    os.path.expandvars(os.path.join("$HOME", ".local", "share")),
-)
-XDG_RUNTIME_DIR = os.getenv("XDG_RUNTIME_DIR")
+
+XDG_DATA_HOME = _path_from_env("XDG_DATA_HOME", HOME / ".local" / "share")
+
+try:
+    XDG_RUNTIME_DIR: Optional[Path] = Path(os.environ["XDG_RUNTIME_DIR"])
+except KeyError:
+    XDG_RUNTIME_DIR = None

--- a/test/test_xdg.py
+++ b/test/test_xdg.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
 import pytest  # pylint: disable=import-error
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch  # noqa
 # pylint: enable=import-error,unused-import
 
-HOME_DIR = "/homedir"
+HOME_DIR = Path("/homedir")
 
 
 @pytest.fixture  # type: ignore
@@ -34,27 +35,27 @@ class TestXdgCacheHome:
     ) -> None:
         """Test when XDG_CACHE_HOME is unset."""
         monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-        monkeypatch.setenv("HOME", HOME_DIR)
+        monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
         from xdg import XDG_CACHE_HOME
 
-        assert XDG_CACHE_HOME == os.path.join(HOME_DIR, ".cache")
+        assert XDG_CACHE_HOME == HOME_DIR / ".cache"
 
     def test_empty(
         self, monkeypatch: "MonkeyPatch", unimport: Callable
     ) -> None:
         """Test when XDG_CACHE_HOME is empty."""
-        monkeypatch.setenv("HOME", HOME_DIR)
+        monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
         monkeypatch.setenv("XDG_CACHE_HOME", "")
         from xdg import XDG_CACHE_HOME
 
-        assert XDG_CACHE_HOME == os.path.join(HOME_DIR, ".cache")
+        assert XDG_CACHE_HOME == HOME_DIR / ".cache"
 
     def test_set(self, monkeypatch: "MonkeyPatch", unimport: Callable) -> None:
         """Test when XDG_CACHE_HOME is set."""
         monkeypatch.setenv("XDG_CACHE_HOME", "/xdg_cache_home")
         from xdg import XDG_CACHE_HOME
 
-        assert XDG_CACHE_HOME == "/xdg_cache_home"
+        assert XDG_CACHE_HOME == Path("/xdg_cache_home")
 
 
 class TestXdgConfigDirs:
@@ -67,7 +68,7 @@ class TestXdgConfigDirs:
         monkeypatch.delenv("XDG_CONFIG_DIRS", raising=False)
         from xdg import XDG_CONFIG_DIRS
 
-        assert XDG_CONFIG_DIRS == ["/etc/xdg"]
+        assert XDG_CONFIG_DIRS == [Path("/etc/xdg")]
 
     def test_empty(
         self, monkeypatch: "MonkeyPatch", unimport: Callable
@@ -76,14 +77,14 @@ class TestXdgConfigDirs:
         monkeypatch.setenv("XDG_CONFIG_DIRS", "")
         from xdg import XDG_CONFIG_DIRS
 
-        assert XDG_CONFIG_DIRS == ["/etc/xdg"]
+        assert XDG_CONFIG_DIRS == [Path("/etc/xdg")]
 
     def test_set(self, monkeypatch: "MonkeyPatch", unimport: Callable) -> None:
         """Test when XDG_CONFIG_DIRS is set."""
         monkeypatch.setenv("XDG_CONFIG_DIRS", "/first:/sec/ond")
         from xdg import XDG_CONFIG_DIRS
 
-        assert XDG_CONFIG_DIRS == ["/first", "/sec/ond"]
+        assert XDG_CONFIG_DIRS == [Path("/first"), Path("/sec/ond")]
 
 
 class TestXdgConfigHome:
@@ -94,27 +95,27 @@ class TestXdgConfigHome:
     ) -> None:
         """Test when XDG_CONFIG_HOME is unset."""
         monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
-        monkeypatch.setenv("HOME", HOME_DIR)
+        monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
         from xdg import XDG_CONFIG_HOME
 
-        assert XDG_CONFIG_HOME == os.path.join(HOME_DIR, ".config")
+        assert XDG_CONFIG_HOME == HOME_DIR / ".config"
 
     def test_empty(
         self, monkeypatch: "MonkeyPatch", unimport: Callable
     ) -> None:
         """Test when XDG_CONFIG_HOME is empty."""
-        monkeypatch.setenv("HOME", HOME_DIR)
+        monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
         monkeypatch.setenv("XDG_CONFIG_HOME", "")
         from xdg import XDG_CONFIG_HOME
 
-        assert XDG_CONFIG_HOME == os.path.join(HOME_DIR, ".config")
+        assert XDG_CONFIG_HOME == HOME_DIR / ".config"
 
     def test_set(self, monkeypatch: "MonkeyPatch", unimport: Callable) -> None:
         """Test when XDG_CONFIG_HOME is set."""
         monkeypatch.setenv("XDG_CONFIG_HOME", "/xdg_config_home")
         from xdg import XDG_CONFIG_HOME
 
-        assert XDG_CONFIG_HOME == "/xdg_config_home"
+        assert XDG_CONFIG_HOME == Path("/xdg_config_home")
 
 
 class TestXdgDataDirs:
@@ -127,7 +128,10 @@ class TestXdgDataDirs:
         monkeypatch.delenv("XDG_DATA_DIRS", raising=False)
         from xdg import XDG_DATA_DIRS
 
-        assert XDG_DATA_DIRS == ["/usr/local/share/", "/usr/share/"]
+        assert XDG_DATA_DIRS == [
+            Path("/usr/local/share/"),
+            Path("/usr/share/"),
+        ]
 
     def test_empty(
         self, monkeypatch: "MonkeyPatch", unimport: Callable
@@ -136,14 +140,17 @@ class TestXdgDataDirs:
         monkeypatch.setenv("XDG_DATA_DIRS", "")
         from xdg import XDG_DATA_DIRS
 
-        assert XDG_DATA_DIRS == ["/usr/local/share/", "/usr/share/"]
+        assert XDG_DATA_DIRS == [
+            Path("/usr/local/share/"),
+            Path("/usr/share/"),
+        ]
 
     def test_set(self, monkeypatch: "MonkeyPatch", unimport: Callable) -> None:
         """Test when XDG_DATA_DIRS is set."""
         monkeypatch.setenv("XDG_DATA_DIRS", "/first/:/sec/ond/")
         from xdg import XDG_DATA_DIRS
 
-        assert XDG_DATA_DIRS == ["/first/", "/sec/ond/"]
+        assert XDG_DATA_DIRS == [Path("/first/"), Path("/sec/ond/")]
 
 
 class TestXdgDataHome:
@@ -154,27 +161,27 @@ class TestXdgDataHome:
     ) -> None:
         """Test when XDG_DATA_HOME is unset."""
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
-        monkeypatch.setenv("HOME", HOME_DIR)
+        monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
         from xdg import XDG_DATA_HOME
 
-        assert XDG_DATA_HOME == os.path.join(HOME_DIR, ".local", "share")
+        assert XDG_DATA_HOME == HOME_DIR / ".local" / "share"
 
     def test_empty(
         self, monkeypatch: "MonkeyPatch", unimport: Callable
     ) -> None:
         """Test when XDG_DATA_HOME is empty."""
-        monkeypatch.setenv("HOME", HOME_DIR)
+        monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
         monkeypatch.setenv("XDG_DATA_HOME", "")
         from xdg import XDG_DATA_HOME
 
-        assert XDG_DATA_HOME == os.path.join(HOME_DIR, ".local", "share")
+        assert XDG_DATA_HOME == HOME_DIR / ".local" / "share"
 
     def test_set(self, monkeypatch: "MonkeyPatch", unimport: Callable) -> None:
         """Test when XDG_DATA_HOME is set."""
         monkeypatch.setenv("XDG_DATA_HOME", "/xdg_data_home")
         from xdg import XDG_DATA_HOME
 
-        assert XDG_DATA_HOME == "/xdg_data_home"
+        assert XDG_DATA_HOME == Path("/xdg_data_home")
 
 
 class TestXdgRuntimeDir:
@@ -196,11 +203,11 @@ class TestXdgRuntimeDir:
         monkeypatch.setenv("XDG_RUNTIME_DIR", "")
         from xdg import XDG_RUNTIME_DIR
 
-        assert XDG_RUNTIME_DIR == ""
+        assert XDG_RUNTIME_DIR == Path("")
 
     def test_set(self, monkeypatch: "MonkeyPatch", unimport: Callable) -> None:
         """Test when XDG_RUNTIME_DIR is set."""
         monkeypatch.setenv("XDG_RUNTIME_DIR", "/xdg_runtime_dir")
         from xdg import XDG_RUNTIME_DIR
 
-        assert XDG_RUNTIME_DIR == "/xdg_runtime_dir"
+        assert XDG_RUNTIME_DIR == Path("/xdg_runtime_dir")


### PR DESCRIPTION
This introduces a backwards incompatible change to the public API: whereas previously paths were returned as strings, they are now returned as [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) objects, which are the new de facto standard for specifying file system paths in Python.

If your code expects strings rather than `pathlib.Path` objects, wrap the variable in a call to [`os.fspath`](https://docs.python.org/3/library/os.html#os.fspath), e.g.
```python
config_home = os.fspath(xdg.XDG_CONFIG_HOME)
```

Closes #32.