### PR TITLE
Ignore relative paths as per specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,18 @@ from xdg import (
 `xdg_cache_home()`, `xdg_config_home()`, and `xdg_data_home()` return
 [`pathlib.Path` objects][path] containing the value of the environment variable
 named `XDG_CACHE_HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME` respectively, or
-the default defined in the specification if the environment variable is unset or
-empty.
+the default defined in the specification if the environment variable is unset,
+empty, or contains a relative path rather than absolute path.
 
 `xdg_config_dirs()` and `xdg_data_dirs()` return a list of `pathlib.Path`
 objects containing the value, split on colons, of the environment variable named
 `XDG_CONFIG_DIRS` and `XDG_DATA_DIRS` respectively, or the default defined in
-the specification if the environment variable is unset or empty.
+the specification if the environment variable is unset or empty. Relative paths
+are ignored, as per the specification.
 
 `xdg_runtime_dir()` returns a `pathlib.Path` object containing the value of the
 `XDG_RUNTIME_DIR` environment variable, or `None` if the environment variable is
-not set.
+not set, or contains a relative path rather than absolute path.
 
 ## Copyright
 

--- a/test/test_xdg.py
+++ b/test/test_xdg.py
@@ -24,8 +24,15 @@ def test_xdg_cache_home_empty(monkeypatch: MonkeyPatch) -> None:
     assert xdg.xdg_cache_home() == HOME_DIR / ".cache"
 
 
-def test_xdg_cache_home_set(monkeypatch: MonkeyPatch) -> None:
-    """Test xdg_cache_home when XDG_CACHE_HOME is set."""
+def test_xdg_cache_home_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_cache_home when XDG_CACHE_HOME is relative path."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_CACHE_HOME", "rela/tive")
+    assert xdg.xdg_cache_home() == HOME_DIR / ".cache"
+
+
+def test_xdg_cache_home_absolute(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_cache_home when XDG_CACHE_HOME is absolute path."""
     monkeypatch.setenv("XDG_CACHE_HOME", "/xdg_cache_home")
     assert xdg.xdg_cache_home() == Path("/xdg_cache_home")
 
@@ -42,9 +49,15 @@ def test_xdg_config_dirs_empty(monkeypatch: MonkeyPatch) -> None:
     assert xdg.xdg_config_dirs() == [Path("/etc/xdg")]
 
 
+def test_xdg_config_dirs_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_config_dirs when XDG_CONFIG_DIRS is relative paths."""
+    monkeypatch.setenv("XDG_CONFIG_DIRS", "rela/tive:ano/ther")
+    assert xdg.xdg_config_dirs() == [Path("/etc/xdg")]
+
+
 def test_xdg_config_dirs_set(monkeypatch: MonkeyPatch) -> None:
     """Test xdg_config_dirs when XDG_CONFIG_DIRS is set."""
-    monkeypatch.setenv("XDG_CONFIG_DIRS", "/first:/sec/ond")
+    monkeypatch.setenv("XDG_CONFIG_DIRS", "/first:rela/tive:/sec/ond")
     assert xdg.xdg_config_dirs() == [Path("/first"), Path("/sec/ond")]
 
 
@@ -62,8 +75,15 @@ def test_xdg_config_home_empty(monkeypatch: MonkeyPatch) -> None:
     assert xdg.xdg_config_home() == HOME_DIR / ".config"
 
 
-def test_xdg_config_home_set(monkeypatch: MonkeyPatch) -> None:
-    """Test xdg_config_home when XDG_CONFIG_HOME is set."""
+def test_xdg_config_home_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_config_home when XDG_CONFIG_HOME is relative path."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_CONFIG_HOME", "rela/tive")
+    assert xdg.xdg_config_home() == HOME_DIR / ".config"
+
+
+def test_xdg_config_home_absolute(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_config_home when XDG_CONFIG_HOME is absolute path."""
     monkeypatch.setenv("XDG_CONFIG_HOME", "/xdg_config_home")
     assert xdg.xdg_config_home() == Path("/xdg_config_home")
 
@@ -86,9 +106,18 @@ def test_xdg_data_dirs_empty(monkeypatch: MonkeyPatch) -> None:
     ]
 
 
+def test_xdg_data_dirs_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_data_dirs when XDG_DATA_DIRS is relative paths."""
+    monkeypatch.setenv("XDG_DATA_DIRS", "rela/tive:ano/ther")
+    assert xdg.xdg_data_dirs() == [
+        Path("/usr/local/share/"),
+        Path("/usr/share/"),
+    ]
+
+
 def test_xdg_data_dirs_set(monkeypatch: MonkeyPatch) -> None:
     """Test xdg_data_dirs when XDG_DATA_DIRS is set."""
-    monkeypatch.setenv("XDG_DATA_DIRS", "/first/:/sec/ond/")
+    monkeypatch.setenv("XDG_DATA_DIRS", "/first/:rela/tive:/sec/ond/")
     assert xdg.xdg_data_dirs() == [Path("/first/"), Path("/sec/ond/")]
 
 
@@ -106,8 +135,15 @@ def test_xdg_data_home_empty(monkeypatch: MonkeyPatch) -> None:
     assert xdg.xdg_data_home() == HOME_DIR / ".local" / "share"
 
 
-def test_xdg_data_home_set(monkeypatch: MonkeyPatch) -> None:
-    """Test xdg_data_home when XDG_DATA_HOME is set."""
+def test_xdg_data_home_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_data_home when XDG_DATA_HOME is relative path."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_DATA_HOME", "rela/tive")
+    assert xdg.xdg_data_home() == HOME_DIR / ".local" / "share"
+
+
+def test_xdg_data_home_absolute(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_data_home when XDG_DATA_HOME is absolute path."""
     monkeypatch.setenv("XDG_DATA_HOME", "/xdg_data_home")
     assert xdg.xdg_data_home() == Path("/xdg_data_home")
 
@@ -121,10 +157,16 @@ def test_xdg_runtime_dir_unset(monkeypatch: MonkeyPatch) -> None:
 def test_xdg_runtime_dir_empty(monkeypatch: MonkeyPatch) -> None:
     """Test xdg_runtime_dir when XDG_RUNTIME_DIR is empty."""
     monkeypatch.setenv("XDG_RUNTIME_DIR", "")
-    assert xdg.xdg_runtime_dir() == Path("")
+    assert xdg.xdg_runtime_dir() is None
 
 
-def test_xdg_runtime_dir_set(monkeypatch: MonkeyPatch) -> None:
-    """Test xdg_runtime_dir when XDG_RUNTIME_DIR is set."""
+def test_xdg_runtime_dir_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_runtime_dir when XDG_RUNTIME_DIR is relative path."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "rela/tive")
+    assert xdg.xdg_runtime_dir() is None
+
+
+def test_xdg_runtime_dir_absolute(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_runtime_dir when XDG_RUNTIME_DIR is absolute path."""
     monkeypatch.setenv("XDG_RUNTIME_DIR", "/xdg_runtime_dir")
     assert xdg.xdg_runtime_dir() == Path("/xdg_runtime_dir")


### PR DESCRIPTION
The specification states:

> All paths set in these environment variables must be absolute. If an implementation encounters a relative path in any of these variables it should consider the path invalid and ignore it.

Closes #54.