### PR TITLE
Add XDG_STATE_HOME support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,16 @@ from xdg import (
     xdg_data_dirs,
     xdg_data_home,
     xdg_runtime_dir,
+    xdg_state_home,
 )
 ```
 
-`xdg_cache_home()`, `xdg_config_home()`, and `xdg_data_home()` return
-[`pathlib.Path` objects][path] containing the value of the environment variable
-named `XDG_CACHE_HOME`, `XDG_CONFIG_HOME`, and `XDG_DATA_HOME` respectively, or
-the default defined in the specification if the environment variable is unset,
-empty, or contains a relative path rather than absolute path.
+`xdg_cache_home()`, `xdg_config_home()`, `xdg_data_home()`, and
+`xdg_state_home()` return [`pathlib.Path` objects][path] containing the value of
+the environment variable named `XDG_CACHE_HOME`, `XDG_CONFIG_HOME`,
+`XDG_DATA_HOME`, and `XDG_STATE_HOME` respectively, or the default defined in
+the specification if the environment variable is unset, empty, or contains a
+relative path rather than absolute path.
 
 `xdg_config_dirs()` and `xdg_data_dirs()` return a list of `pathlib.Path`
 objects containing the value, split on colons, of the environment variable named

--- a/src/xdg/__init__.py
+++ b/src/xdg/__init__.py
@@ -16,11 +16,12 @@
 
 """XDG Base Directory Specification variables.
 
-xdg_cache_home(), xdg_config_home(), and xdg_data_home() return
-pathlib.Path objects containing the value of the environment variable
-named XDG_CACHE_HOME, XDG_CONFIG_HOME, and XDG_DATA_HOME respectively,
-or the default defined in the specification if the environment variable
-is unset, empty, or contains a relative path rather than absolute path.
+xdg_cache_home(), xdg_config_home(), xdg_data_home(), and xdg_state_home()
+return pathlib.Path objects containing the value of the environment variable
+named XDG_CACHE_HOME, XDG_CONFIG_HOME, XDG_DATA_HOME, and XDG_STATE_HOME
+respectively, or the default defined in the specification if the environment
+variable is unset, empty, or contains a relative path rather than absolute
+path.
 
 xdg_config_dirs() and xdg_data_dirs() return a list of pathlib.Path
 objects containing the value, split on colons, of the environment
@@ -47,6 +48,7 @@ __all__ = [
     "xdg_data_dirs",
     "xdg_data_home",
     "xdg_runtime_dir",
+    "xdg_state_home",
     "XDG_CACHE_HOME",
     "XDG_CONFIG_DIRS",
     "XDG_CONFIG_HOME",
@@ -161,6 +163,11 @@ def xdg_runtime_dir() -> Optional[Path]:
     if value and os.path.isabs(value):
         return Path(value)
     return None
+
+
+def xdg_state_home() -> Path:
+    """Return a Path corresponding to XDG_STATE_HOME."""
+    return _path_from_env("XDG_STATE_HOME", _home_dir() / ".local" / "state")
 
 
 # The following variables are deprecated, but remain for backward compatibility.

--- a/test/test_xdg.py
+++ b/test/test_xdg.py
@@ -170,3 +170,30 @@ def test_xdg_runtime_dir_absolute(monkeypatch: MonkeyPatch) -> None:
     """Test xdg_runtime_dir when XDG_RUNTIME_DIR is absolute path."""
     monkeypatch.setenv("XDG_RUNTIME_DIR", "/xdg_runtime_dir")
     assert xdg.xdg_runtime_dir() == Path("/xdg_runtime_dir")
+
+
+def test_xdg_state_home_unset(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_state_home when XDG_STATE_HOME is unset."""
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    assert xdg.xdg_state_home() == HOME_DIR / ".local" / "state"
+
+
+def test_xdg_state_home_empty(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_state_home when XDG_STATE_HOME is empty."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_STATE_HOME", "")
+    assert xdg.xdg_state_home() == HOME_DIR / ".local" / "state"
+
+
+def test_xdg_state_home_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_state_home when XDG_STATE_HOME is relative path."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_STATE_HOME", "rela/tive")
+    assert xdg.xdg_state_home() == HOME_DIR / ".local" / "state"
+
+
+def test_xdg_state_home_absolute(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_state_home when XDG_STATE_HOME is absolute path."""
+    monkeypatch.setenv("XDG_STATE_HOME", "/xdg_state_home")
+    assert xdg.xdg_state_home() == Path("/xdg_state_home")


### PR DESCRIPTION
XDG_STATE_HOME was added in version 0.8 of the basedir spec, released on 8 May 2021. It is intended for storing application state, such as undo history or window layout.